### PR TITLE
Sphero.start needs to actually retry on connection issues

### DIFF
--- a/lib/sphero.rb
+++ b/lib/sphero.rb
@@ -17,20 +17,22 @@ class Sphero
   class << self
     def start(dev, &block)
       retries_left = DEFAULT_RETRIES
-      sphero = self.new dev
-      if (block_given?)
-        begin
-           sphero.instance_eval(&block)
-        ensure
-           sphero.close
+      begin
+        sphero = self.new dev
+        if (block_given?)
+          begin
+             sphero.instance_eval(&block)
+          ensure
+             sphero.close
+          end
+          return nil
         end
-        return nil
+        return sphero      
+      rescue Errno::EBUSY
+        puts retries_left
+        retries_left = retries_left - 1
+        retry unless retries_left < 0
       end
-      return sphero
-    rescue Errno::EBUSY
-      puts retries_left
-      retries_left = retries_left - 1
-      retry unless retries_left > 0
     end
   end
 


### PR DESCRIPTION
I was having connection issues with my Sphero, and it turns out that at some point the begin in the self.start method got removed, so it wasn't actually rescuing properly if it couldn't connect.

Additionally, the retry code was only retrying _unless_ the retry number was _greater_ than zero.   I've changed it to a less-than, which means it actually retries now. 
