### PR TITLE
Add Stabilization method

### DIFF
--- a/lib/sphero.rb
+++ b/lib/sphero.rb
@@ -104,6 +104,10 @@ class Sphero
     write Request::Heading.new(@seq, degrees(h) )
   end
 
+  def stabilization= on
+    write Request::Stabilization.new(@seq, on)
+  end
+
   def color colorname, persistant = false
     color = COLORS[colorname]
     rgb color[:r], color[:g], color[:b], persistant

--- a/lib/sphero/request.rb
+++ b/lib/sphero/request.rb
@@ -101,6 +101,18 @@ class Sphero
       end
     end
 
+    class Stabilization < Sphero
+      def initialize seq, on
+        super(seq, [on ? 1 : 0])
+        @cid = 0x02
+      end
+
+      private
+      def packet_body
+        @data.pack 'C'
+      end
+    end
+
     class Sleep < Request
       def initialize seq, wakeup, macro
         super(seq, [wakeup, macro])

--- a/test/test_sphero.rb
+++ b/test/test_sphero.rb
@@ -77,6 +77,12 @@ class TestSphero < MiniTest::Unit::TestCase
     @sphero.sphero_sleep wakeup, macro
   end
 
+  def test_stabilization
+    Sphero::Request::Stabilization.expects(:new).with(@seq, true)
+    @sphero.expects(:write)
+    @sphero.stabilization = true
+  end
+
   def test_roll
     speed = 1
     heading = 2


### PR DESCRIPTION
Allows the user to turn on/off the auto stabilization. Useful when either using Sphero as a gestural controller, and also when calibrating the heading.
